### PR TITLE
Ignore mime-associated warnings (Jupyter book)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,7 @@ exclude_patterns = [
 
 suppress_warnings = [
     'misc.highlighting_failure',  # Suppress warning in exception in digits_vae
+    'mystnb.unknown_mime_type',  # Suppress warning for unknown mime type (e.g. colab-display-data+json)
 ]
 
 # -- Options for myst ----------------------------------------------


### PR DESCRIPTION
The RTD Sphinx build is failing due to some warnings about unknown mime types. I am adding these to the `conf.py` as these should be ok to ignore.